### PR TITLE
swapping the order of values when writing baseline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,12 +539,9 @@ where
         }
 
         // Send command and data to sensor
+        // Note that the order of the two parameters is inverted when writing
+        // compared to when reading.
         let mut buf = [0; 4];
-        //According to the docs:
-        // After a power-up or soft reset, the baseline of the baseline compensation
-        // algorithm can be restored by sending first an "Init_air_quality” command
-        // followed by a “Set_baseline” command with the two baseline values as
-        // parameters in the order as (TVOC, CO2eq).
         BigEndian::write_u16(&mut buf[0..2], baseline.tvoc);
         BigEndian::write_u16(&mut buf[2..4], baseline.co2eq);
         self.send_command_and_data(Command::SetBaseline, &buf)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ mod tests {
         assert_eq!(dev.get_last_address(), Some(0x58));
         assert_eq!(dev.get_write_data(), &[
             /* command: */ 0x20, 0x1E,
-            /* data + crc8: */ 0x12, 0x34, 0x37, 0x56, 0x78, 0x7D,
+            /* data + crc8: */ 0x56, 0x78, 0x7D, 0x12, 0x34, 0x37,
         ]);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,8 +540,13 @@ where
 
         // Send command and data to sensor
         let mut buf = [0; 4];
-        BigEndian::write_u16(&mut buf[0..2], baseline.co2eq);
-        BigEndian::write_u16(&mut buf[2..4], baseline.tvoc);
+        //According to the docs:
+        // After a power-up or soft reset, the baseline of the baseline compensation
+        // algorithm can be restored by sending first an "Init_air_quality” command
+        // followed by a “Set_baseline” command with the two baseline values as
+        // parameters in the order as (TVOC, CO2eq).
+        BigEndian::write_u16(&mut buf[0..2], baseline.tvoc);
+        BigEndian::write_u16(&mut buf[2..4], baseline.co2eq);
         self.send_command_and_data(Command::SetBaseline, &buf)?;
 
         // Max duration according to datasheet (Table 10)


### PR DESCRIPTION
I was having some issues reading/writing the baseline values on my sgp30 and found a small bug.  It looks like Sensirion reversed the order of values between reading and writing the baseline.  

When reading you get co2 then tvoc, but when writing they want tvoc then co2.

This PR fixes the ordering of the set_baseline command.