### PR TITLE
Update to `embedded-hal` 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ default = []
 
 [dependencies]
 byteorder = { version = "1", default-features = false }
-embedded-hal = "0.2"
+embedded-hal = "1"
 num-traits = { version = "0.2", default-features = false }
-sensirion-i2c = "0.2"
+sensirion-i2c = "0.3"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = { version = "0.10.0", features = ["eh0"] }
+linux-embedded-hal = "0.4"
+embedded-hal-mock = { version = "0.11.1", features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,4 +1,4 @@
-use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayNs;
 use linux_embedded_hal::{Delay, I2cdev};
 use sgp30::Sgp30;
 
@@ -6,7 +6,7 @@ fn measure_loop(sgp: &mut Sgp30<I2cdev, Delay>) -> ! {
     let mut i = 0;
     loop {
         if i != 0 {
-            Delay.delay_ms(1000u16 - 12 - 25);
+            Delay.delay_ms(1000u32 - 12 - 25);
         }
         if i % 10 == 0 {
             let baseline = sgp.get_baseline().unwrap();


### PR DESCRIPTION
This commit updates the crate to v1.0.0 of `embedded-hal`. Naturally,
this is a breaking change, so I've gone ahead and incremented the
version to reflect that.

In a follow-up PR, I intend to add support for `embedded-hal-async` as
well, but I wanted to make that change separately.