### PR TITLE
Make `build_and_test` CI job actually run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cargo check --all-features
+      - run: cargo test --all-features
 
   ensure_no_std:
     name: Ensure no_std


### PR DESCRIPTION
I noticed that it wasn't actually running the tests, just `cargo check`. This commit adds a `cargo test` step so that tests are run on CI.